### PR TITLE
Freebsd fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PREFIX = /usr
+
 CC	 =	gcc
 
 LDFLAGS	+=	-lncurses
@@ -42,17 +44,17 @@ ${PROG}: ${OBJS}
 	${CC} ${CFLAGS} ${OBJS} ${LDFLAGS} -o $@;
 
 install:
-	install -o root -g bin -m 555 -s -S -d mg ${DESTDIR}/usr/bin/mg;
-	install -o root -g bin -m 444 -S -d mg.1 ${DESTDIR}/usr/share/man/man1/mg.1;
-	if [ ! -d ${DESTDIR}/usr/share/doc/mg/ ]; then \
-		mkdir -p ${DESTDIR}/usr/share/doc/mg/; \
+	install -o root -g bin -m 555 -s -S -d mg ${PREFIX}/bin/mg;
+	install -o root -g bin -m 444 -S -d mg.1 ${PREFIX}/share/man/man1/mg.1;
+	if [ ! -d ${PREFIX}/share/doc/mg/ ]; then \
+		mkdir -p ${PREFIX}/share/doc/mg/; \
 	fi;
-	install -o root -g bin -m 444 -S -d tutorial ${DESTDIR}/usr/share/doc/mg/tutorial;
+	install -o root -g bin -m 444 -S -d tutorial ${PREFIX}/share/doc/mg/tutorial;
 
 uninstall:
-	rm -f ${DESTDIR}/usr/bin/mg;
-	rm -f ${DESTDIR}/usr/share/man/man1/mg.1;
-	rm -rf ${DESTDIR}/usr/share/doc/mg;
+	rm -f ${PREFIX}/bin/mg;
+	rm -f ${PREFIX}/share/man/man1/mg.1;
+	rm -rf ${PREFIX}/share/doc/mg;
 
 clean:
 	rm -f mg ${OBJS};

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-PREFIX = /usr
+PORTNAME	= mg
+PREFIX		= /usr
+MANPREFIX	= ${PREFIX}/share/man
+DOCSDIR		= ${PREFIX}/share/doc/${PORTNAME}
 
 CC	 =	gcc
 
@@ -45,16 +48,16 @@ ${PROG}: ${OBJS}
 
 install:
 	install -o root -g bin -m 555 -s -S -d mg ${PREFIX}/bin/mg;
-	install -o root -g bin -m 444 -S -d mg.1 ${PREFIX}/share/man/man1/mg.1;
-	if [ ! -d ${PREFIX}/share/doc/mg/ ]; then \
-		mkdir -p ${PREFIX}/share/doc/mg/; \
+	install -o root -g bin -m 444 -S -d mg.1 ${MANPREFIX}/man1/mg.1;
+	if [ ! -d ${DOCSDIR} ]; then \
+		mkdir -p ${DOCSDIR}; \
 	fi;
-	install -o root -g bin -m 444 -S -d tutorial ${PREFIX}/share/doc/mg/tutorial;
+	install -o root -g bin -m 444 -S -d tutorial ${DOCSDIR}/tutorial;
 
 uninstall:
 	rm -f ${PREFIX}/bin/mg;
-	rm -f ${PREFIX}/share/man/man1/mg.1;
-	rm -rf ${PREFIX}/share/doc/mg;
+	rm -f ${MANPREFIX}/man1/mg.1;
+	rm -rf ${DOCSDIR};
 
 clean:
 	rm -f mg ${OBJS};

--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,12 @@ ${PROG}: ${OBJS}
 	${CC} ${CFLAGS} ${OBJS} ${LDFLAGS} -o $@;
 
 install:
-	install -o root -g bin -m 555 -s -S -d mg ${PREFIX}/bin/mg;
-	install -o root -g bin -m 444 -S -d mg.1 ${MANPREFIX}/man1/mg.1;
+	install -o root -g bin -m 555 -S mg ${PREFIX}/bin/mg;
+	install -o root -g bin -m 444 -S mg.1 ${MANPREFIX}/man1/mg.1;
 	if [ ! -d ${DOCSDIR} ]; then \
 		mkdir -p ${DOCSDIR}; \
 	fi;
-	install -o root -g bin -m 444 -S -d tutorial ${DOCSDIR}/tutorial;
+	install -o root -g bin -m 444 -S tutorial ${DOCSDIR}/tutorial;
 
 uninstall:
 	rm -f ${PREFIX}/bin/mg;

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-PORTNAME	= mg
-PREFIX		= /usr
-MANPREFIX	= ${PREFIX}/share/man
-DOCSDIR		= ${PREFIX}/share/doc/${PORTNAME}
+PORTNAME	?= mg
+PREFIX		?= /usr
+MANPREFIX	?= ${PREFIX}/share/man
+DOCSDIR		?= ${PREFIX}/share/doc/${PORTNAME}
 
 CC	 =	gcc
 


### PR DESCRIPTION
Hi,

Thanks for the easy-to-use mg repo! Here are a few quick fixes to Makefile paths to make it easier to install on different OSes (e.g. FreeBSD expects mg to be installed under /usr/local and the man directory is under /usr/local/man, not share/man).

Here's how I install it on FreeBSD:

    make
    sudo PREFIX=/usr/local MANPREFIX=/usr/local/man make install

One more fix is needed for the program to build on FreeBSD: replace LOGIN_NAME_MAX with _SC_LOGIN_NAME_MAX. I didn't include that fix because I didn't check that it works under Linux.

Lassi